### PR TITLE
Add assertions for core invariants

### DIFF
--- a/src/main/java/valencia/Valencia.java
+++ b/src/main/java/valencia/Valencia.java
@@ -24,9 +24,14 @@ public class Valencia {
      * @param filePath Path to the save file.
      */
     public Valencia(String filePath) {
+        assert filePath != null && !filePath.isBlank() : "filePath must be non-null and non-blank";
         ui = new Ui();
         storage = new Storage(filePath);
         taskList = storage.load();
+
+        assert ui != null : "ui should be initialized";
+        assert storage != null : "storage should be initialized";
+        assert taskList != null : "taskList should not be null after loading";
     }
 
     /**
@@ -52,6 +57,7 @@ public class Valencia {
         );
         while (true) {
             String input = ui.readCommand();
+            assert input != null : "Ui.readCommand() should not return null";
             String response = getResponse(input);
             ui.showMessage(response);
 
@@ -66,6 +72,9 @@ public class Valencia {
      * Take user input and returns Valencia reply as a string
      */
     public String getResponse(String input) {
+        assert input != null : "input passed into getResponse should not be null";
+        assert taskList != null : "taskList should be initialized";
+        assert storage != null : "storage should be initialized";
         String trimmed = input.trim();
         try {
             if (trimmed.isEmpty()) {
@@ -77,16 +86,20 @@ public class Valencia {
                 commandType = "Mark";
                 int taskNum = Parser.parseTaskNumber(trimmed, "mark");
                 Parser.validateTaskNumber(taskNum, taskList);
-                taskList.markDone(taskNum - 1);
+                int index = taskNum - 1;
+                assert index >= 0 && index < taskList.size() : "Validated taskNum should map to a valid index";
+                taskList.markDone(index);
                 storage.save(taskList);
-                return String.format("Nice! I've marked this task as done:\n%s", taskList.get(taskNum - 1));
+                return String.format("Nice! I've marked this task as done:\n%s", taskList.get(index));
             }
 
             if (lower.startsWith("unmark")) {
                 commandType = "Mark";
                 int taskNum = Parser.parseTaskNumber(trimmed, "unmark");
                 Parser.validateTaskNumber(taskNum, taskList);
-                taskList.unmarkDone(taskNum - 1);
+                int index = taskNum - 1;
+                assert index >= 0 && index < taskList.size() : "Validated taskNum should map to a valid index";
+                taskList.unmarkDone(index);
                 storage.save(taskList);
                 return String.format("OK, I've marked this task as not done yet:\n%s", taskList.get(taskNum - 1));
             }
@@ -94,7 +107,9 @@ public class Valencia {
             if (lower.startsWith("todo")) {
                 commandType = "Add";
                 String desc = Parser.parseTodoDescription(trimmed);
+                assert desc != null : "Todo description should not be null";
                 Task todoTask = new Todo(desc);
+                assert todoTask != null : "todoTask should not be null";
                 taskList.add(todoTask);
                 storage.save(taskList);
                 return String.format("Got it. I've added this task:\n%s\nNow you have %d tasks in the list.",
@@ -104,6 +119,7 @@ public class Valencia {
             if (lower.startsWith("deadline")) {
                 commandType = "Add";
                 Task deadlineTask = Parser.parseDeadline(trimmed);
+                assert deadlineTask != null : "parseDeadline should not return null";
                 taskList.add(deadlineTask);
                 storage.save(taskList);
                 return String.format("Got it. I've added this task:\n%s\nNow you have %d tasks in the list.",
@@ -113,6 +129,7 @@ public class Valencia {
             if (lower.startsWith("event")) {
                 commandType = "Add";
                 Task eventTask = Parser.parseEvent(trimmed);
+                assert eventTask != null : "parseEvent should not return null";
                 taskList.add(eventTask);
                 storage.save(taskList);
                 return String.format("Got it. I've added this task:\n%s\nNow you have %d tasks in the list.",
@@ -123,7 +140,10 @@ public class Valencia {
                 commandType = "Delete";
                 int taskNum = Parser.parseTaskNumber(trimmed, "delete");
                 Parser.validateTaskNumber(taskNum, taskList);
-                Task removedTask = taskList.remove(taskNum - 1);
+                int index = taskNum - 1;
+                assert index >= 0 && index < taskList.size() : "Validated taskNum should map to a valid index";
+                Task removedTask = taskList.remove(index);
+                assert removedTask != null : "remove should return a Task";
                 storage.save(taskList);
                 return String.format("Noted. I've removed this task:\n%s\nNow you have %d tasks in the list.",
                         removedTask, taskList.size());
@@ -132,6 +152,7 @@ public class Valencia {
             if (lower.startsWith("find")) {
                 commandType = "Find";
                 String keyword = Parser.parseFindKeyword(trimmed);
+                assert keyword != null : "find keyword should not be null";
                 return "Here are the matching tasks in your list:\n" + taskList.formatMatches(keyword);
             }
 

--- a/src/main/java/valencia/parser/Parser.java
+++ b/src/main/java/valencia/parser/Parser.java
@@ -23,9 +23,15 @@ public class Parser {
      * @throws ValenciaException If task number is missing or not a number.
      */
     public static int parseTaskNumber(String input, String commandWord) {
+        assert input != null : "input should not be null";
+        assert commandWord != null && !commandWord.isBlank() : "commandWord should be non-null and non-blank";
+        assert input.length() >= commandWord.length() : "input should be at least as long as commandWord";
+
         String rest = input.substring(commandWord.length()).trim();
         try {
-            return Integer.parseInt(rest);
+            int taskNum = Integer.parseInt(rest);
+            assert taskNum > 0 : "Parsed task number should be positive";
+            return taskNum;
         } catch (NumberFormatException e) {
             throw new ValenciaException("Sorry! I need a task number!");
         }
@@ -39,6 +45,9 @@ public class Parser {
      * @throws ValenciaException If task number is out of range.
      */
     public static void validateTaskNumber(int taskNum, TaskList taskList) {
+        assert taskList != null : "taskList should not be null";
+        assert taskNum > 0 : "taskNum should be positive";
+
         if (taskNum < 1 || taskNum > taskList.size()) {
             throw new ValenciaException("That task number does not exist :P");
         }
@@ -52,10 +61,14 @@ public class Parser {
      * @throws ValenciaException If description is empty.
      */
     public static String parseTodoDescription(String input) {
+        assert input != null : "input should not be null";
+        assert input.length() >= 4 : "input should contain at least the command word 'todo'";
+
         String desc = input.substring(4).trim();
         if (desc.isEmpty()) {
             throw new ValenciaException("I did not receive a task :(");
         }
+        assert !desc.isBlank() : "Todo description should not be blank after validation";
         return desc;
     }
 
@@ -67,6 +80,9 @@ public class Parser {
      * @throws ValenciaException If format is wrong or date is invalid.
      */
     public static Deadline parseDeadline(String input) {
+        assert input != null : "input should not be null";
+        assert input.length() >= 8 : "input should contain at least the command word 'deadline'";
+
         String desc = input.substring(8).trim(); // remove "deadline"
         String[] parts = desc.split(" /by ", 2);
         if (parts.length < 2) {
@@ -76,6 +92,9 @@ public class Parser {
         String taskDesc = parts[0].trim();
         String dateStr = parts[1].trim();
 
+        assert !taskDesc.isBlank() : "Deadline description should not be blank when '/by' is present";
+        assert !dateStr.isBlank() : "Deadline date string should not be blank when '/by' is present";
+
         LocalDate by;
         try {
             by = LocalDate.parse(dateStr);
@@ -83,7 +102,9 @@ public class Parser {
             throw new ValenciaException("Wrong format! Date must be yyyy-MM-dd!");
         }
 
-        return new Deadline(taskDesc, by);
+        Deadline deadline = new Deadline(taskDesc, by);
+        assert deadline != null : "Deadline object should not be null";
+        return deadline;
     }
 
     /**
@@ -94,20 +115,31 @@ public class Parser {
      * @throws ValenciaException If format is wrong.
      */
     public static Event parseEvent(String input) {
-        String desc = input.substring(5).trim();
+        assert input != null : "input should not be null";
+        assert input.length() >= 5 : "input should contain at least the command word 'event'";
+
+        String desc = input.substring(5).trim(); // remove "event"
         String[] firstPart = desc.split(" /from ", 2);
         if (firstPart.length < 2) {
             throw new ValenciaException("Wrong event format!");
         }
+
         String input1 = firstPart[0].trim();
         String[] secondPart = firstPart[1].split(" /to ", 2);
         if (secondPart.length < 2) {
             throw new ValenciaException("Wrong event format!");
         }
+
         String input2 = secondPart[0].trim();
         String input3 = secondPart[1].trim();
 
-        return new Event(input1, input2, input3);
+        assert !input1.isBlank() : "Event description should not be blank when '/from' is present";
+        assert !input2.isBlank() : "Event start should not be blank when '/to' is present";
+        assert !input3.isBlank() : "Event end should not be blank when '/to' is present";
+
+        Event event = new Event(input1, input2, input3);
+        assert event != null : "Event object should not be null";
+        return event;
     }
 
     /**
@@ -117,12 +149,15 @@ public class Parser {
      * @return Keyword to search.
      */
     public static String parseFindKeyword(String input) {
+        assert input != null : "input should not be null";
+        assert input.length() >= 4 : "input should contain at least the command word 'find'";
+
         String keyword = input.substring(4).trim(); // remove "find"
         if (keyword.isEmpty()) {
             throw new ValenciaException("Find what?");
         }
+        assert !keyword.isBlank() : "Find keyword should not be blank after validation";
         return keyword;
     }
-
 }
 

--- a/src/main/java/valencia/task/Task.java
+++ b/src/main/java/valencia/task/Task.java
@@ -14,6 +14,7 @@ public class Task {
      * @param description Task description.
      */
     public Task(String description) {
+        assert description != null && !description.isBlank() : "Task description must be non-null and non-blank";
         this.description = description;
         this.isDone = false;
     }
@@ -24,6 +25,7 @@ public class Task {
      * @return Task description.
      */
     public String getDescription() {
+        assert description != null : "description should never be null";
         return description;
     }
 
@@ -41,6 +43,7 @@ public class Task {
      */
     public void markDone() {
         this.isDone = true;
+        assert isDone : "isDone should be true after markDone";
     }
 
     /**
@@ -48,6 +51,7 @@ public class Task {
      */
     public void unmarkDone() {
         this.isDone = false;
+        assert !isDone : "isDone should be false after unmarkDone";
     }
 
     /**
@@ -56,11 +60,8 @@ public class Task {
      * @return "[X]" if done, otherwise "[ ]".
      */
     public String checkDone() {
-        if (this.isDone) {
-            return "[X]";
-        } else {
-            return "[ ]";
-        }
+        // isDone is boolean so it is always a valid state
+        return isDone ? "[X]" : "[ ]";
     }
 
     /**
@@ -70,6 +71,7 @@ public class Task {
      */
     @Override
     public String toString() {
-        return checkDone() + " " + this.description;
+        assert description != null : "description should never be null";
+        return checkDone() + " " + description;
     }
 }

--- a/src/main/java/valencia/task/TaskList.java
+++ b/src/main/java/valencia/task/TaskList.java
@@ -16,7 +16,9 @@ public class TaskList {
      * @param task Task to add.
      */
     public void add(Task task) {
+        assert task != null : "task to add should not be null";
         tasks.add(task);
+        assert tasks.contains(task) : "task should be present after add";
     }
 
     /**
@@ -26,7 +28,10 @@ public class TaskList {
      * @return The task at the index.
      */
     public Task get(int index) {
-        return tasks.get(index);
+        assert index >= 0 && index < tasks.size() : "index out of bounds: " + index;
+        Task task = tasks.get(index);
+        assert task != null : "stored task should not be null";
+        return task;
     }
 
     /**
@@ -35,15 +40,16 @@ public class TaskList {
      * @return Task count.
      */
     public int size() {
+        assert tasks.size() >= 0 : "tasks size should never be negative";
         return tasks.size();
     }
-
 
     /**
      * Prints all tasks with numbering to stdout.
      */
     public void printList() {
         for (int i = 0; i < tasks.size(); i++) {
+            assert tasks.get(i) != null : "stored task should not be null";
             System.out.println(String.format("%s. %s", i + 1, tasks.get(i)));
         }
     }
@@ -54,6 +60,8 @@ public class TaskList {
      * @param index Index in the list (0-based).
      */
     public void markDone(int index) {
+        assert index >= 0 && index < tasks.size() : "index out of bounds: " + index;
+        assert tasks.get(index) != null : "stored task should not be null";
         tasks.get(index).markDone();
     }
 
@@ -63,6 +71,8 @@ public class TaskList {
      * @param index Index in the list (0-based).
      */
     public void unmarkDone(int index) {
+        assert index >= 0 && index < tasks.size() : "index out of bounds: " + index;
+        assert tasks.get(index) != null : "stored task should not be null";
         tasks.get(index).unmarkDone();
     }
 
@@ -73,7 +83,10 @@ public class TaskList {
      * @return The removed task.
      */
     public Task remove(int index) {
-        return tasks.remove(index);
+        assert index >= 0 && index < tasks.size() : "index out of bounds: " + index;
+        Task removed = tasks.remove(index);
+        assert removed != null : "remove should return a non-null task";
+        return removed;
     }
 
     /**
@@ -82,23 +95,31 @@ public class TaskList {
      * @return Unmodifiable list of tasks.
      */
     public List<Task> getTasks() {
-        return Collections.unmodifiableList(tasks);
+        List<Task> view = Collections.unmodifiableList(tasks);
+        assert view != null : "unmodifiable view should not be null";
+        return view;
     }
 
     /**
      * Finds task by keyword and return the tasks that matches.
+     *
      * @param keyword User keyword (e.g. book)
      * @return List of tasks that match
      */
     public List<Task> findByKeyword(String keyword) {
+        assert keyword != null : "keyword should not be null";
+
         List<Task> matches = new ArrayList<>();
         String key = keyword.toLowerCase();
 
         for (Task t : tasks) {
+            assert t != null : "stored task should not be null";
+            assert t.getDescription() != null : "task description should not be null";
             if (t.getDescription().toLowerCase().contains(key)) {
                 matches.add(t);
             }
         }
+        assert matches != null : "matches list should not be null";
         return matches;
     }
 
@@ -106,17 +127,26 @@ public class TaskList {
      * Print out tasks that matches
      *
      * @param keyword User keyword (e.g. book)
-     *
      */
     public void printMatches(String keyword) {
+        assert keyword != null : "keyword should not be null";
+
         int count = 0;
+        String key = keyword.toLowerCase();
+
         for (int i = 0; i < tasks.size(); i++) {
-            if (tasks.get(i).getDescription().toLowerCase().contains(keyword.toLowerCase())) {
+            Task t = tasks.get(i);
+            assert t != null : "stored task should not be null";
+            assert t.getDescription() != null : "task description should not be null";
+
+            if (t.getDescription().toLowerCase().contains(key)) {
                 count++;
-                System.out.println(String.format("%d.%s", count, tasks.get(i)));
+                System.out.println(String.format("%d.%s", count, t));
             }
         }
+        assert count >= 0 : "match count should never be negative";
     }
+
     // =========================
     // GUI
     // =========================
@@ -128,18 +158,26 @@ public class TaskList {
         }
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < tasks.size(); i++) {
+            assert tasks.get(i) != null : "stored task should not be null";
             sb.append(i + 1).append(". ").append(tasks.get(i)).append("\n");
         }
-        return sb.toString().trim();
+        String result = sb.toString().trim();
+        assert !result.isBlank() : "formatted list should not be blank when tasks is non-empty";
+        return result;
     }
 
     /** Returns matching tasks as a string (for GUI). */
     public String formatMatches(String keyword) {
+        assert keyword != null : "keyword should not be null";
+
         String key = keyword.toLowerCase();
         int count = 0;
         StringBuilder sb = new StringBuilder();
 
         for (Task t : tasks) {
+            assert t != null : "stored task should not be null";
+            assert t.getDescription() != null : "task description should not be null";
+
             if (t.getDescription().toLowerCase().contains(key)) {
                 count++;
                 sb.append(count).append(". ").append(t).append("\n");
@@ -149,6 +187,8 @@ public class TaskList {
         if (count == 0) {
             return "(no matching tasks)";
         }
-        return sb.toString().trim();
+        String result = sb.toString().trim();
+        assert !result.isBlank() : "formatted matches should not be blank when there are matches";
+        return result;
     }
 }


### PR DESCRIPTION
User commands depend on several assumptions such as non-null inputs and valid task indexes.

When these assumptions are violated, the app can fail in unexpected ways and the root cause is harder to diagnose.

Add assertions to document and enforce key invariants in Valencia, Parser, TaskList, Storage, and Task so that developer mistakes are caught early during development and testing.