### PR TITLE
Use streams for keyword filtering

### DIFF
--- a/src/main/java/valencia/task/TaskList.java
+++ b/src/main/java/valencia/task/TaskList.java
@@ -3,6 +3,7 @@ package valencia.task;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Stores and manages a list of tasks.
@@ -91,17 +92,13 @@ public class TaskList {
      * @return List of tasks that match
      */
     public List<Task> findByKeyword(String keyword) {
-        List<Task> matches = new ArrayList<>();
         String key = keyword.toLowerCase();
 
-        for (Task t : tasks) {
-            if (t.getDescription().toLowerCase().contains(key)) {
-                matches.add(t);
-            }
-        }
-        return matches;
+        return tasks.stream()
+                .filter(t -> t.getDescription().toLowerCase().contains(key))
+                .collect(Collectors.toList());
     }
-
+    
     /**
      * Print out tasks that matches
      *


### PR DESCRIPTION
TaskList keyword search currently uses a manual loop to filter matching tasks.

The loop-based approach works but is more verbose than necessary for a simple filter operation.

Use a stream pipeline to filter tasks by keyword and collect matching tasks into a list. This makes the intent clearer and keeps the search logic concise.